### PR TITLE
adds external-dns, cert-manager

### DIFF
--- a/stage/gitops/applications/cert-manager/application.yaml
+++ b/stage/gitops/applications/cert-manager/application.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    targetRevision: v1.15.0
+    chart: cert-manager
+    helm:
+      values: |
+        enableCertificateOwnerRef: true
+        installCRDs: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated: {}
+    syncOptions:
+    - CreateNamespace=true
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/replicas
+  revisionHistoryLimit: 10

--- a/stage/gitops/applications/cert-manager/cluster-issuer.yaml
+++ b/stage/gitops/applications/cert-manager/cluster-issuer.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: dannbohn@gmail.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource that will be used to store the account's private key.
+      name: letsencrypt-account-private-key
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: nginx

--- a/stage/gitops/applications/external-dns/application.yaml
+++ b/stage/gitops/applications/external-dns/application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-dns
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: external-dns
+    repoURL: https://kubernetes-sigs.github.io/external-dns/
+    targetRevision: 1.14.5
+    helm:
+      values: |
+        serviceAccount:
+          annotations:
+            eks.amazonaws.com/role-arn: "arn:aws:iam::304225443749:role/external-dns"
+        provider:
+          name: aws
+        env:
+          - name: AWS_DEFAULT_REGION
+            value: us-east-1
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: kube-system


### PR DESCRIPTION
external-dns needs the eks.amazonaws.com/role-arn annotation on it's service account, this is minted with terraform isra.tf. 